### PR TITLE
Example of how a small API change may help for more efficient MC pricing where possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,3 @@ docsbuild/
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
-
-testing_ground.jl

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ docsbuild/
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+
+testing_ground.jl

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DiffEqNoiseProcess = "77a26b50-5914-5dd7-bc55-306e6241c503"
@@ -24,6 +25,7 @@ StochasticDiffEq = "789caeaf-c7a9-5a7d-9973-96adeb23e2a0"
 
 [compat]
 Accessors = "0.1.42"
+BenchmarkTools = "1.6.0"
 DataInterpolations = "7.2.0"
 Dates = "1.10"
 DiffEqNoiseProcess = "5.24.1"
@@ -42,7 +44,6 @@ Statistics = "1.10"
 StochasticDiffEq = "6"
 Test = "1.10"
 julia = "1.10"
-
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/pricing_methods/least_squares_montecarlo.jl
+++ b/src/pricing_methods/least_squares_montecarlo.jl
@@ -84,6 +84,15 @@ function extract_spot_grid(sol_anti::Tuple{EnsembleSolution,EnsembleSolution})
     return spot_grid
 end
 
+""" 
+    Get the spot grid from a simulation by first making an SDE problem and then simulating paths. Returns the extracted spot grid and a boolean indicating if the spot grid matrix has been transposed. 
+"""
+function get_spot_grid(prob, method)
+    sde_prob = sde_problem(prob, method.mc_method.dynamics, method.mc_method.strategy)
+    sol = Hedgehog.simulate_paths(sde_prob, method.mc_method, method.mc_method.config.variance_reduction)
+    return Hedgehog.extract_spot_grid(sol)
+end
+
 """
     solve(prob::PricingProblem, method::LSM)
 
@@ -135,6 +144,45 @@ function solve(
     return LSMSolution(prob, method, price, stopping_info, spot_grid)
 end
 
+""" This works the same as solve(), but allows for faster implementations for special cases and uses a spot-grid that is performant for column-major memory access. """
+function solve_quick(
+    prob::PricingProblem{VanillaOption{TS,TE,American,C,S},I},
+    method::L,
+) where {TS,TE,I<:AbstractMarketInputs,C,S, L<:LSM}
+
+    T = yearfrac(prob.market_inputs.referenceDate, prob.payoff.expiry)
+    spot_grid = get_spot_grid(prob, method)
+
+    npaths, ntimes = size(spot_grid)
+    nsteps = ntimes - 1
+    discount = df(prob.market_inputs.rate, add_yearfrac(prob.market_inputs.referenceDate, T / nsteps))
+
+    stopping_info = [(nsteps, prob.payoff(spot_grid[p, nsteps+1])) for p = 1:npaths]
+
+    for i = nsteps:-1:2
+        t = i - 1
+
+        continuation =
+            [discount^(stopping_info[p][1] - t) * stopping_info[p][2] for p = 1:npaths]
+
+        payoff_t = prob.payoff.(spot_grid[:, i])
+        in_the_money = findall(payoff_t .> 0)
+        isempty(in_the_money) && continue
+
+        x = spot_grid[in_the_money, i]
+        y = continuation[in_the_money]
+        poly = Polynomials.fit(x, y, method.degree)
+        cont_value = map(poly, x)
+
+        update_stopping_info!(stopping_info, in_the_money, cont_value, payoff_t, t)
+    end
+
+    discounted_values = [discount^t * val for (t, val) in stopping_info]
+    price = mean(discounted_values)
+
+    return LSMSolution(prob, method, price, stopping_info, spot_grid)
+end
+
 """
     update_stopping_info!(
         stopping_info::Vector{Tuple{Int, U}},
@@ -162,4 +210,54 @@ function update_stopping_info!(
 ) where {T,S,U}
     exercise = payoff_t[paths] .> cont_value
     stopping_info[paths[exercise]] .= [(t, payoff_t[p]) for p in paths[exercise]]
+end
+
+function get_spot_grid(
+    prob::PricingProblem{V, <:BlackScholesInputs},
+    method::L,
+) where {V, L<:LSM}
+    market = prob.market_inputs
+    K = method.mc_method.config.steps
+    var_red = method.mc_method.config.variance_reduction
+    T = yearfrac(market.referenceDate, prob.payoff.expiry)
+
+    r = zero_rate(market.rate, 0.0)
+    σ = get_vol(market.sigma, nothing, nothing)
+    S₀ = market.spot
+    Δt = T/K
+    N = method.mc_method.config.trajectories
+
+    return simulate_paths_black_scholes(r, σ, S₀, Δt, N, K, var_red, method.mc_method.config.seeds)
+end
+
+function simulate_paths_black_scholes(r, σ, S₀, Δt, N, K, ::NoVarianceReduction, seed)
+    rng = Xoshiro(seed[1])
+    drift_part = ((r - 0.5 * σ^2) * Δt)
+    diffusion_part = σ * sqrt(Δt)
+    paths = Matrix{typeof(drift_part*diffusion_part*S₀)}(undef, N, K)
+    randn!(rng, paths)
+    @views for k in 1:K
+        if k == 1
+            paths[:, 1] = S₀ .* exp.(drift_part .+ diffusion_part .* paths[:,1])
+            continue
+        end
+        paths[:, k] = paths[:, k - 1] .* exp.(drift_part .+ diffusion_part .* view(paths, :, k))
+    end
+    return paths
+end
+function simulate_paths_black_scholes(r, σ, S₀, Δt, N, K, ::Antithetic, seed)
+    rng = Xoshiro(seed[1])
+    drift_part = ((r - 0.5 * σ^2) * Δt)
+    diffusion_part = σ * sqrt(Δt)
+    paths = Matrix{typeof(drift_part*diffusion_part*S₀)}(undef, 2*N, K)
+    randn!(rng, view(paths, 1:N, :))
+    paths[N+1:2*N, :] .= -paths[1:N, :]
+    @views for k in 1:K
+        if k == 1
+            paths[:, 1] = S₀ .* exp.(drift_part .+ diffusion_part .* paths[:,1])
+            continue
+        end
+        paths[:, k] = paths[:, k - 1] .* exp.(drift_part .+ diffusion_part .* view(paths, :, k))
+    end
+    return paths
 end

--- a/testing_ground.jl
+++ b/testing_ground.jl
@@ -1,0 +1,133 @@
+using Revise
+using Hedgehog
+using Dates
+using Printf
+using BenchmarkTools
+using Random 
+struct BSExactProblem{T,U,V,W,X}
+    r::T
+    σ::U
+    t₀::V
+    S₀::W
+    T::X
+end
+
+struct BSExactProblemSimulated{T}
+    S::T
+end
+
+function sde_problem2(
+    problem::PricingProblem{Payoff, Inputs},
+    ::LognormalDynamics,
+    ::BlackScholesExact,
+    ) where {Payoff, Inputs <: BlackScholesInputs}
+    market = problem.market_inputs
+    T = yearfrac(market.referenceDate, problem.payoff.expiry)
+
+    r = zero_rate(market.rate, 0.0)
+    σ = get_vol(market.sigma, nothing, nothing)
+    S₀ = market.spot
+    t₀ = zero(S₀)
+
+    r, σ, t₀, S₀ = promote(r, σ, t₀, S₀)
+
+    return BSExactProblem(r, σ, t₀, S₀, T)
+end
+
+function simulate_paths(
+    sde_prob::BSExactProblem,
+    method::MonteCarlo,
+    ::Hedgehog.NoVarianceReduction
+)
+    Δt = sde_prob.T - sde_prob.t₀
+    σ = sde_prob.σ
+    S₀ = sde_prob.S₀
+    r = sde_prob.r
+    N = method.config.trajectories
+
+    drift_part = ((r - 0.5 * σ^2) * Δt)
+    diffusion_part = σ * sqrt(Δt)
+    S_out = S₀ .* exp.(drift_part .+ diffusion_part .* randn(N))
+    return BSExactProblemSimulated(S_out)
+end
+
+function simulate_paths(
+    sde_prob::BSExactProblem,
+    method::MonteCarlo,
+    ::Hedgehog.Antithetic
+)
+    Δt = sde_prob.T - sde_prob.t₀
+    σ = sde_prob.σ
+    S₀ = sde_prob.S₀
+    r = sde_prob.r
+    N = method.config.trajectories
+
+    drift_part = ((r - 0.5 * σ^2) * Δt)
+    diffusion_part = σ * sqrt(Δt)
+
+    # We ensure that normal_sol is of the right type
+    normal_sol = Vector{typeof(drift_part*diffusion_part)}(undef, N)
+    randn!(normal_sol)
+
+    antithetic_sol = S₀ .* exp.(drift_part .- diffusion_part .* normal_sol)
+    normal_sol .= S₀ .* exp.(drift_part .+ diffusion_part .* normal_sol)
+    return (BSExactProblemSimulated(normal_sol), BSExactProblemSimulated(antithetic_sol))
+end
+
+function reduce_payoffs(
+    result::Tuple{BSExactProblemSimulated, BSExactProblemSimulated},
+    payoff::F,
+    ::Hedgehog.Antithetic,
+    dynamics::Hedgehog.PriceDynamics,
+    strategy::Hedgehog.SimulationStrategy,
+) where {F}
+    S1, S2 = result
+    return (payoff(S1.S) + payoff(S2.S))/2
+end
+
+function solve2(
+    prob::PricingProblem{VanillaOption{TS, TE, European, C, Spot}, I},
+    method::MonteCarlo{D, S},
+) where {TS, TE, C, I, D, S}
+    strategy = method.strategy
+    dynamics = method.dynamics
+    config = method.config
+
+    sde_prob = sde_problem2(prob, method.dynamics, method.strategy)
+    ens = simulate_paths(sde_prob, method, config.variance_reduction)
+    payoffs = reduce_payoffs(ens, prob.payoff, config.variance_reduction, dynamics, strategy)
+    discount = df(prob.market_inputs.rate, prob.payoff.expiry)
+    price = discount * mean(payoffs)
+
+    return Hedgehog.MonteCarloSolution(prob, method, price, ens)
+end
+
+function test()
+    spot = 100.0
+    strike = 100.0
+    rate = 0.05
+    sigma = 0.20
+    reference_date = Date(2023, 1, 1)
+    expiry = reference_date + Year(1)
+
+    # Create the payoff (European call option)
+    payoff = VanillaOption(strike, expiry, European(), Call(), Spot())
+
+    # Create market inputs
+    market_inputs = BlackScholesInputs(reference_date, rate, spot, sigma)
+
+    # Create pricing problem
+    prob = PricingProblem(payoff, market_inputs)
+
+    trajectories = 5_000
+    mc_exact_method =
+        MonteCarlo(LognormalDynamics(), BlackScholesExact(), SimulationConfig(trajectories))
+    mc_exact_solution = solve(prob, mc_exact_method)
+    display(mc_exact_solution.price)
+    mc_exact_solution = solve2(prob, mc_exact_method)
+    display(mc_exact_solution.price)
+    display(@benchmark solve($prob, $mc_exact_method))
+    display(@benchmark solve2($prob, $mc_exact_method))
+end
+
+test()


### PR DESCRIPTION
To illustrate my point in #10, I've written a small example how the MC European and LSM pricing methods may be slightly changed (illustrated by the functions `solve_quick`) to have substantial speed-ups (300x for European, 2x for American) and allocation decreases (890,000 to 26, 1,900,000 to 7968 respectively). 

The idea is to combine sequential calls to `sde_problem` and `simulate_paths` into one combined function, `simulate_paths_from_problem`. In the generic case, this function simply calls these two functions in order. However, we may now dispatch on the `PricingProblem`, which allows us to use more efficient simulation schemes if available. A similar thing can be done for least-squares monte-carlo with a function `get_spot_grid`, which allows dispatch. For the Black-Scholes model, we even get a spot-grid in a more memory-friendly layout! 

See `testing_ground.jl` for a runable script to see the differences! 